### PR TITLE
DynamicTypeMapping

### DIFF
--- a/src/main/python/ipystate/dynamic_type_mapping.py
+++ b/src/main/python/ipystate/dynamic_type_mapping.py
@@ -1,0 +1,55 @@
+from abc import ABC
+from collections import defaultdict, MutableMapping
+from typing import Mapping, Tuple, Union, VT_co
+
+
+class DynamicTypeMapping(MutableMapping, ABC):
+    Key = Union[type, Tuple[str, str]]
+
+    def __init__(self, data: Mapping[Key, VT_co] = ()):
+        self._module_name_value = defaultdict(dict)
+        for item in data:
+            print(item)
+            self[item] = data[item]
+
+    def __getitem__(self, key: Key):
+        if isinstance(key, type):
+            module = key.__module__
+            name = key.__name__
+        elif isinstance(key, tuple):
+            module, name = key
+        else:
+            raise TypeError(key)
+        name_value = self._module_name_value[module]
+        if name not in name_value:
+            raise KeyError(key)
+        return name_value[name]
+
+    def __delitem__(self, key: Key):
+        if isinstance(key, type):
+            module = key.__module__
+            name = key.__name__
+        elif isinstance(key, tuple):
+            module, name = key
+        else:
+            raise TypeError(key)
+        del self._module_name_value[module][name]
+
+    def __setitem__(self, key: Key, value):
+        if isinstance(key, type):
+            module = key.__module__
+            name = key.__name__
+        elif isinstance(key, tuple):
+            module, name = key
+        else:
+            raise TypeError(key)
+        self._module_name_value[module][name] = value
+
+    def __iter__(self):
+        return ((module, name) for module, name_value in self._module_name_value.items() for name in name_value)
+
+    def __len__(self):
+        return sum(map(len, self._module_name_value), 0)
+
+    def __repr__(self):
+        return repr(self._module_name_value)

--- a/src/main/python/ipystate/impl/changedetector.py
+++ b/src/main/python/ipystate/impl/changedetector.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 from enum import Enum
 
+from ipystate.dynamic_type_mapping import DynamicTypeMapping
+
 
 class ChangedState(Enum):
     NEW = 0
@@ -41,7 +43,7 @@ class HashChangeDetector(ChangeDetector):
     def __init__(self):
         super().__init__()
         self._hashes = dict()
-        self._dispatch = dict()
+        self._dispatch = DynamicTypeMapping()
 
     def reset(self):
         self._hashes = dict()


### PR DESCRIPTION
Импорты модулей пользователем могут происходить в самые неожиданные моменты (вроде наливки состояния после перезапуска jupyter-kernel), а одновременно с этим будут происходить обращения за функциями хеширования. Поэтому недостаточно просто обновить таблицу функций хеширования после наливки стейта, а её нужно обновлять непрерывно.
Кажется, придётся завязываться не ссылками на конкретные типы, а на их имена (`typ.__module__ == 'pandas.core.frame' and typ.__name__ == 'DataFrame'`), чтобы не на каждый поиск хэшера идти в `sys.modules`, а затем что-то импортировать.
