### PR TITLE
CLOUD-75286: Handle boto3.session.Session().client() serialization failure

### DIFF
--- a/src/main/python/ipystate/serialization.py
+++ b/src/main/python/ipystate/serialization.py
@@ -215,6 +215,7 @@ class Serializer:
                 chunk = cf.current_chunk()
                 serialized_vars.append((var_name, chunk))
             except Exception as e:
+                pickler.framer.end_framing()
                 pickler.memo = committed_memo
                 non_serialized_var_names.add(var_name)
                 self._on_var_serialize_error(var_name, var_value, e)


### PR DESCRIPTION
```
AttributeError: Can't get attribute 'ParameterAlias.alias_parameter_in_call' on <module 'botocore.handlers' from '/usr/local/lib/python3.7/site-packages/botocore/handlers.py'>
```
